### PR TITLE
fix(script): fix encode 'bytes' object has no attribute 'encode' error

### DIFF
--- a/aplc.py
+++ b/aplc.py
@@ -149,7 +149,7 @@ def main():
         
     # load SHA1 hash from file
     f = open(sys.argv[1], 'rb')
-    gest = f.read(hashlib.sha1().digest_size).encode('hex')
+    gest = f.read(hashlib.sha1().digest_size).hex()
     f.close()
 
     # check hash length


### PR DESCRIPTION
## Context 

Solves #9 

## Description

Fix encode 'bytes' object has no attribute 'encode' error